### PR TITLE
Do not print auth header to the logs

### DIFF
--- a/bxgateway/cmd/gateway/main.go
+++ b/bxgateway/cmd/gateway/main.go
@@ -278,7 +278,6 @@ func run(
 	// Ensure we sanitize the auth header before logging it anywhere.
 	re := regexp.MustCompile(`(?mi)-{1,2}auth-header[\s=]{1}(\S*)`)
 	for _, match := range re.FindAllString(cfg.RuntimeEnnvironment.Arguments, -1) {
-		fmt.Println("Match:", match)
 		cfg.RuntimeEnnvironment.Arguments = strings.ReplaceAll(cfg.RuntimeEnnvironment.Arguments, match, "-auth-header=REDACTED")
 	}
 

--- a/bxgateway/cmd/gateway/main.go
+++ b/bxgateway/cmd/gateway/main.go
@@ -90,7 +90,7 @@ func main() {
 			&cli.IntFlag{Name: ofrPortFlag, Aliases: []string{"bdn-port"}, Value: 8888, Usage: "DEPRECATED - kept to not to crash existing configurations"},
 			&cli.IntFlag{Name: ofrGRPCPortFlag, Aliases: []string{"bdn-grpc-port"}, Value: 5005, Usage: "Closest ofr relay's GRPC port"},
 			&cli.IntFlag{Name: udpServerPortFlag, Value: 18888, Usage: "Localhost UDP port used to run a server for communication with ofr - should be open for inbound and outbound traffic"},
-			&cli.StringFlag{Name: authHeaderFlag, Required: true, Usage: "Auth header issued by bloXroute"},
+			&cli.StringFlag{Name: authHeaderFlag, Required: true, Usage: "Auth header issued by bloXroute", EnvVars: []string{"BX_AUTH_HEADER"}},
 			&cli.StringSliceFlag{Name: broadcastAddressesFlag, Usage: "Sets extra addresses to send shreds received from OFR and Solana Node"},
 			&cli.BoolFlag{Name: broadcastFromOfrOnlyFlag, Aliases: []string{"broadcast-from-bdn-only"}, Usage: "Do not send traffic from Solana Node to extra addresses specified with --broadcast-addresses"},
 			&cli.BoolFlag{Name: noValidatorFlag, Value: false, Usage: "Run gw without node, only for elite/ultra accounts"},


### PR DESCRIPTION

- [Support auth header as env var](https://github.com/bloXroute-Labs/solana-gateway/commit/a93126f2f67d8f60a7de65af8138adf22b373eeb) 

  Currently application prints all startup args as part of logger
  initialization, which means auth header ends up in logs. This is not
  secure, and we would like to avoid this, hence we add support to pass
  auth header as env var.

  Code that prints statrup args is part of the lib https://github.com/bloXroute-Labs/bxcommon-go/blob/develop/logger/log.go#L82

- [Do not print match of redacted auth header](https://github.com/bloXroute-Labs/solana-gateway/commit/e6cb160a985f651b04a59eb3c6aea3fd5f35384b) 

  This actually prints the auth header to stdout, which I think is not
  intended.

